### PR TITLE
Migrate from `motor` to `pymongo`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,3 @@
 # display code coverage results, and enable debug logging
 addopts = --verbose -ra --cov --log-cli-level=DEBUG
 asyncio_mode = auto
-asyncio_default_fixture_loop_scope = session

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     install_requires=[
         "aiohttp",
         "cyhy-config @ git+https://github.com/cisagov/cyhy-config.git@v1",
-        "cyhy-db @ git+https://github.com/cisagov/cyhy-db.git@v1",
+        "cyhy-db @ git+https://github.com/cisagov/cyhy-db.git@bugfix/motor-to-pymongo",
         "cyhy-logging @ git+https://github.com/cisagov/cyhy-logging.git@v1",
         "jsonschema",
         "rich",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     install_requires=[
         "aiohttp",
         "cyhy-config @ git+https://github.com/cisagov/cyhy-config.git@v1",
-        "cyhy-db @ git+https://github.com/cisagov/cyhy-db.git@bugfix/motor-to-pymongo",
+        "cyhy-db @ git+https://github.com/cisagov/cyhy-db.git@v1",
         "cyhy-logging @ git+https://github.com/cisagov/cyhy-logging.git@v1",
         "jsonschema",
         "rich",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     install_requires=[
         "aiohttp",
         "cyhy-config @ git+https://github.com/cisagov/cyhy-config.git@v1",
-        "cyhy-db @ git+https://github.com/cisagov/cyhy-db.git@v1",
+        "cyhy-db @ git+https://github.com/cisagov/cyhy-db.git@v2",
         "cyhy-logging @ git+https://github.com/cisagov/cyhy-logging.git@v1",
         "jsonschema",
         "rich",

--- a/src/cyhy_cvesync/_version.py
+++ b/src/cyhy_cvesync/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,12 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 """
 
 # Standard Python Libraries
-import asyncio
 import logging
 import os
 import time
 
 # Third-Party Libraries
 import docker
-from motor.core import AgnosticClient
 import pytest
 from rich.logging import RichHandler
 
@@ -22,9 +20,6 @@ MONGO_INITDB_ROOT_USERNAME = os.environ.get("MONGO_INITDB_ROOT_USERNAME", "mongo
 MONGO_INITDB_ROOT_PASSWORD = os.environ.get("MONGO_INITDB_ROOT_PASSWORD", "secret")
 DATABASE_NAME = os.environ.get("DATABASE_NAME", "test")
 MONGO_EXPRESS_PORT = os.environ.get("MONGO_EXPRESS_PORT", 8081)
-
-# Set the default event loop policy to be compatible with asyncio
-AgnosticClient.get_io_loop = asyncio.get_running_loop
 
 
 @pytest.fixture(autouse=True)
@@ -145,7 +140,7 @@ def db_name(mongodb_container):
     yield DATABASE_NAME
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True)
 async def db_client(db_uri):
     """Fixture for client init."""
     print(f"Connecting to {db_uri}")

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 # Third-Party Libraries
 from aiohttp import ClientResponseError, ClientSession
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 import pytest
 
 # cisagov Libraries
@@ -32,7 +32,7 @@ def test_release_version():
 
 async def test_connection_motor(db_uri, db_name):
     """Test the database connection."""
-    client = AsyncIOMotorClient(db_uri)
+    client = AsyncMongoClient(db_uri)
     db = client[db_name]
     server_info = await db.command("ping")
     assert server_info["ok"] == 1.0, "Direct database ping failed"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the tests in this repo to use [PyMongo](https://pymongo.readthedocs.io/en/latest/api/pymongo/asynchronous/index.html) instead of [Motor](https://motor.readthedocs.io/en/stable/), mimicking changes made in [Beanie 2.0.0](https://github.com/BeanieODM/beanie/releases/tag/2.0.0), as well as those made in https://github.com/cisagov/cyhy-db/pull/13.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The changes in Beanie 2.0.0 caused our [tests to fail](https://github.com/cisagov/cyhy-db/actions/runs/16558925434/job/46824855164#step:8:23) because the Motor module was no longer included in the Beanie installation.

Note that we can no longer re-use the same database client for multiple tests because [`AsyncMongoClient` is not thread safe and can only be used by a single event loop](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/#method-signature-changes).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

All automated tests pass, with the exception of the linter, but that will fail until #6 is merged.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches (revert https://github.com/cisagov/cyhy-cvesync/commit/6533953a984585b53d4c6069bbae4e84ee652ad9)
- [x] Update cyhy-db version tag in setup.py to `v2` after https://github.com/cisagov/cyhy-db/pull/13 is merged. 
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
