### PR TITLE
Support NVD 2.0 JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ and then load the data into to your database.
 
 ```python
 import asyncio
-from cyhy_cvesync import DEFAULT_CVE_URL_PATTERN
+from cyhy_cvesync import DEFAULT_CVE_AUTHORITATIVE_SOURCE, DEFAULT_CVE_URL_PATTERN
 from cyhy_cvesync.cve_sync import process_urls
 from cyhy_db import initialize_db
 from cyhy_db.models import CVEDoc
@@ -73,7 +73,7 @@ async def main():
     cve_url = DEFAULT_CVE_URL_PATTERN.format(year=2024)
     print(f"Processing CVE data from: {cve_url}...")
     created_cve_docs_count, updated_cve_docs_count, deleted_cve_docs_count = await process_urls(
-        [cve_url], cve_data_gzipped=True, concurrency=1)
+        [cve_url], cve_data_gzipped=True, concurrency=1,cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE)
 
     print(f"Created CVE documents: {created_cve_docs_count}")
     print(f"Updated CVE documents: {updated_cve_docs_count}")
@@ -90,12 +90,12 @@ Output:
 
 ```console
 CVE documents in DB before sync: 20
-Processing CVE data from: https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2024.json.gz...
+Processing CVE data from: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2024.json.gz...
 Deleting outdated CVE docs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Created CVE documents: 12174
+Created CVE documents: 18272
 Updated CVE documents: 0
 Deleted CVE documents: 0
-CVE documents in DB after sync: 12194
+CVE documents in DB after sync: 18272
 ```
 
 ### Environment Variables ###

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ async def main():
     cve_url = DEFAULT_CVE_URL_PATTERN.format(year=2024)
     print(f"Processing CVE data from: {cve_url}...")
     created_cve_docs_count, updated_cve_docs_count, deleted_cve_docs_count = await process_urls(
-        [cve_url], cve_data_gzipped=True, concurrency=1,cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE)
+        [cve_url], cve_data_gzipped=True, concurrency=1, cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE)
 
     print(f"Created CVE documents: {created_cve_docs_count}")
     print(f"Updated CVE documents: {updated_cve_docs_count}")

--- a/src/cyhy_cvesync/__init__.py
+++ b/src/cyhy_cvesync/__init__.py
@@ -7,6 +7,7 @@
 #   directly used, it populates the value package_name.__version__, which is
 #   used to get version information about this Python package.
 
+DEFAULT_CVE_AUTHORITATIVE_SOURCE = "nvd@nist.gov"
 DEFAULT_CVE_URL_PATTERN = (
     "https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-{year}.json.gz"
 )
@@ -14,4 +15,4 @@ DEFAULT_CVE_URL_PATTERN = (
 from ._version import __version__  # noqa: F401, E402
 from .main import do_cve_sync  # noqa: E402
 
-__all__ = [DEFAULT_CVE_URL_PATTERN, "do_cve_sync"]
+__all__ = [DEFAULT_CVE_AUTHORITATIVE_SOURCE, DEFAULT_CVE_URL_PATTERN, "do_cve_sync"]

--- a/src/cyhy_cvesync/__init__.py
+++ b/src/cyhy_cvesync/__init__.py
@@ -8,7 +8,7 @@
 #   used to get version information about this Python package.
 
 DEFAULT_CVE_URL_PATTERN = (
-    "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{year}.json.gz"
+    "https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-{year}.json.gz"
 )
 
 from ._version import __version__  # noqa: F401, E402

--- a/src/cyhy_cvesync/_version.py
+++ b/src/cyhy_cvesync/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "1.2.1"
+__version__ = "2.0.0"

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -20,6 +20,7 @@ from cyhy_db.models import CVEDoc
 ALLOWED_URL_SCHEMES = ["http", "https"]
 CVE_URL_RETRY_WAIT_SEC = 5
 MAX_CVE_URL_RETRIES = 10
+PREFERRED_CVSS_METRICS = ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]
 
 # Map to track existing CVE documents that were not updated
 cve_map: Dict[str, CVEDoc] = {}
@@ -58,6 +59,8 @@ async def process_cve_json(
         id(asyncio.current_task()),
         len(cve_items),
     )
+    # Create a set of preferred CVSS metrics for quick lookup
+    preferred_cvss_metrics_set = set(PREFERRED_CVSS_METRICS)
     for cve in cve_items:
         try:
             cve_id = cve["cve"]["id"]
@@ -70,15 +73,9 @@ async def process_cve_json(
         if not cve_id:
             raise ValueError("CVE ID is empty.")
 
-        # Only process CVEs that have CVSS V2 or V3 data
-        if any(
-            k in cve["cve"].get("metrics", {})
-            for k in [
-                "cvssMetricV2",
-                "cvssMetricV30",
-                "cvssMetricV31",
-            ]
-        ):
+        # Only process CVEs that have our preferred CVSS metrics
+        metrics = cve.get("cve", {}).get("metrics", {}).keys()
+        if metrics & preferred_cvss_metrics_set:
             # Check if the CVE document already exists in the database
             global cve_map
             async with cve_map_lock:
@@ -88,7 +85,7 @@ async def process_cve_json(
             cvss_base_score = None
             cvss_version_temp = None
             try:
-                for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
+                for v in PREFERRED_CVSS_METRICS:
                     if v in cve["cve"].get("metrics", {}):
                         for metric in cve["cve"]["metrics"][v]:
                             if metric.get("source") == cve_authoritative_source:
@@ -101,7 +98,7 @@ async def process_cve_json(
 
                 if cvss_base_score is None or cvss_version_temp is None:
                     logger.debug(
-                        "Skipping %s; no CVSS v2 or v3 metric found from authoritative source (%s).",
+                        "Skipping %s; no preferred CVSS metrics found from authoritative source (%s).",
                         cve_id,
                         cve_authoritative_source,
                     )

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -95,8 +95,8 @@ async def process_cve_json(cve_json: dict) -> Tuple[int, int]:
                         cvss_version_temp = metric["cvssData"]["version"]
                         break
                 else:
-                    logger.error("CVE object: %s", cve)
-                    raise ValueError("No Primary CVSS metric found.")
+                    logger.warning("Skipping %s; no Primary CVSS metric found.", cve_id)
+                    continue
             except KeyError:
                 logger.error("CVE object: %s", cve)
                 raise ValueError("JSON does not look like valid CVE data.")

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -100,7 +100,7 @@ async def process_cve_json(
                         break
 
                 if cvss_base_score is None or cvss_version_temp is None:
-                    logger.warning(
+                    logger.debug(
                         "Skipping %s; no CVSS v2 or v3 metric found from authoritative source (%s).",
                         cve_id,
                         cve_authoritative_source,

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -20,6 +20,7 @@ from cyhy_db.models import CVEDoc
 ALLOWED_URL_SCHEMES = ["http", "https"]
 CVE_URL_RETRY_WAIT_SEC = 5
 MAX_CVE_URL_RETRIES = 10
+# Preferred CVSS metrics listed in order of preference
 PREFERRED_CVSS_METRICS = ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]
 
 # Map to track existing CVE documents that were not updated

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -28,12 +28,15 @@ cve_map_lock = asyncio.Lock()
 logger = logging.getLogger(f"{CYHY_ROOT_LOGGER}.{__name__}")
 
 
-async def process_cve_json(cve_json: dict) -> Tuple[int, int]:
+async def process_cve_json(
+    cve_json: dict, cve_authoritative_source: str
+) -> Tuple[int, int]:
     """
     Process the provided CVEs JSON and update the database with their contents.
 
     Args:
         cve_json (dict): The JSON data containing information about CVEs.
+        cve_authoritative_source (str): The authoritative source for CVE data.
 
     Returns:
         Tuple[int, int]: A tuple containing the counts of created and updated
@@ -185,6 +188,7 @@ async def process_urls(
     cve_urls: List[str],
     cve_data_gzipped: bool,
     concurrency: int,
+    cve_authoritative_source: str,
 ) -> Tuple[int, int, int]:
     """
     Process URLs containing CVE data.
@@ -197,6 +201,7 @@ async def process_urls(
         cve_urls (List[str]): A list of URLs containing CVE data.
         cve_data_gzipped (bool): A flag indicating whether the CVE data is gzipped.
         concurrency (int): The number of concurrent URL requests to make and process.
+        cve_authoritative_source (str): The authoritative source for CVE data.
 
     Returns:
         Tuple[int, int, int]: A tuple containing the counts of created, updated,
@@ -218,7 +223,9 @@ async def process_urls(
         async with semaphore:
             logging.info("Processing URL: %s", cve_url)
             cve_json = await fetch_cve_data(session, cve_url, cve_data_gzipped)
-            created_count, updated_count = await process_cve_json(cve_json)
+            created_count, updated_count = await process_cve_json(
+                cve_json, cve_authoritative_source
+            )
             async with cve_docs_count_lock:
                 created_cve_docs_count += created_count
                 updated_cve_docs_count += updated_count

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -45,10 +45,10 @@ async def process_cve_json(cve_json: dict) -> Tuple[int, int]:
     created_cve_docs_count = 0
     updated_cve_docs_count = 0
 
-    if cve_json.get("CVE_data_type") != "CVE":
+    if cve_json.get("format") != "NVD_CVE":
         raise ValueError("JSON does not look like valid CVE data.")
 
-    cve_items = cve_json.get("CVE_Items", [])
+    cve_items = cve_json.get("vulnerabilities", [])
 
     logger.info(
         "Async task %d: Starting to process %d CVEs",
@@ -57,7 +57,7 @@ async def process_cve_json(cve_json: dict) -> Tuple[int, int]:
     )
     for cve in cve_items:
         try:
-            cve_id = cve["cve"]["CVE_data_meta"]["ID"]
+            cve_id = cve["cve"]["id"]
         except KeyError:
             # JSON might be malformed, so we'll log what the CVE object looks like
             # and then raise an error
@@ -68,20 +68,35 @@ async def process_cve_json(cve_json: dict) -> Tuple[int, int]:
             raise ValueError("CVE ID is empty.")
 
         # Only process CVEs that have CVSS V2 or V3 data
-        if any(k in cve["impact"] for k in ["baseMetricV2", "baseMetricV3"]):
+        if any(
+            k in cve["cve"].get("metrics", {})
+            for k in [
+                "cvssMetricV2",
+                "cvssMetricV30",
+                "cvssMetricV31",
+            ]
+        ):
             # Check if the CVE document already exists in the database
             global cve_map
             async with cve_map_lock:
                 cve_doc = cve_map.pop(cve_id, None)
 
-            version = "V3" if "baseMetricV3" in cve["impact"] else "V2"
+            # Determine newest CVSS metrics version in the CVE data
+            metrics_version = None
+            for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
+                if v in cve["cve"]["metrics"]:
+                    metrics_version = v
+                    break
+
             try:
-                cvss_base_score = cve["impact"]["baseMetric" + version][
-                    "cvss" + version
-                ]["baseScore"]
-                cvss_version_temp = cve["impact"]["baseMetric" + version][
-                    "cvss" + version
-                ]["version"]
+                for metric in cve["cve"]["metrics"][metrics_version]:
+                    if metric["type"] == "Primary":
+                        cvss_base_score = metric["cvssData"]["baseScore"]
+                        cvss_version_temp = metric["cvssData"]["version"]
+                        break
+                else:
+                    logger.error("CVE object: %s", cve)
+                    raise ValueError("No Primary CVSS metric found.")
             except KeyError:
                 logger.error("CVE object: %s", cve)
                 raise ValueError("JSON does not look like valid CVE data.")

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -81,21 +81,23 @@ async def process_cve_json(cve_json: dict) -> Tuple[int, int]:
             async with cve_map_lock:
                 cve_doc = cve_map.pop(cve_id, None)
 
-            # Determine newest CVSS metrics version in the CVE data
-            metrics_version = None
-            for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
-                if v in cve["cve"]["metrics"]:
-                    metrics_version = v
-                    break
-
+            # Determine newest CVSS metrics version containing a "Primary"
+            # metric in the CVE data
+            cvss_base_score = None
+            cvss_version_temp = None
             try:
-                for metric in cve["cve"]["metrics"][metrics_version]:
-                    if metric["type"] == "Primary":
-                        cvss_base_score = metric["cvssData"]["baseScore"]
-                        cvss_version_temp = metric["cvssData"]["version"]
-                        break
-                else:
-                    logger.warning("Skipping %s; no Primary CVSS metric found.", cve_id)
+                for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
+                    if v in cve["cve"].get("metrics", {}):
+                        for metric in cve["cve"]["metrics"][v]:
+                            if metric.get("type") == "Primary":
+                                cvss_base_score = metric["cvssData"]["baseScore"]
+                                cvss_version_temp = metric["cvssData"]["version"]
+                                break
+
+                if cvss_base_score is None or cvss_version_temp is None:
+                    logger.warning(
+                        "Skipping %s; no Primary CVSS v2 or v3 metric found.", cve_id
+                    )
                     continue
             except KeyError:
                 logger.error("CVE object: %s", cve)

--- a/src/cyhy_cvesync/cve_sync.py
+++ b/src/cyhy_cvesync/cve_sync.py
@@ -84,22 +84,26 @@ async def process_cve_json(
             async with cve_map_lock:
                 cve_doc = cve_map.pop(cve_id, None)
 
-            # Determine newest CVSS metrics version containing a "Primary"
-            # metric in the CVE data
+            # Grab newest CVSS metrics from the authoritative source
             cvss_base_score = None
             cvss_version_temp = None
             try:
                 for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
                     if v in cve["cve"].get("metrics", {}):
                         for metric in cve["cve"]["metrics"][v]:
-                            if metric.get("type") == "Primary":
+                            if metric.get("source") == cve_authoritative_source:
                                 cvss_base_score = metric["cvssData"]["baseScore"]
                                 cvss_version_temp = metric["cvssData"]["version"]
                                 break
+                    if cvss_base_score is not None:
+                        # Break out of outer loop
+                        break
 
                 if cvss_base_score is None or cvss_version_temp is None:
                     logger.warning(
-                        "Skipping %s; no Primary CVSS v2 or v3 metric found.", cve_id
+                        "Skipping %s; no CVSS v2 or v3 metric found from authoritative source (%s).",
+                        cve_id,
+                        cve_authoritative_source,
                     )
                     continue
             except KeyError:

--- a/src/cyhy_cvesync/main.py
+++ b/src/cyhy_cvesync/main.py
@@ -60,7 +60,10 @@ async def do_cve_sync(
     # Fetch the CVE URLs and put the CVE data into the database
     created_cve_docs_count, updated_cve_docs_count, deleted_cve_docs_count = (
         await process_urls(
-            cve_urls, config.cvesync.json_url_gzipped, config.cvesync.url_concurrency
+            cve_urls,
+            config.cvesync.json_url_gzipped,
+            config.cvesync.url_concurrency,
+            config.cvesync.cve_authoritative_source,
         )
     )
 

--- a/src/cyhy_cvesync/models/config_model.py
+++ b/src/cyhy_cvesync/models/config_model.py
@@ -6,7 +6,7 @@ from typing import Optional
 # Third-Party Libraries
 from pydantic import BaseModel, ConfigDict, Field
 
-from .. import DEFAULT_CVE_URL_PATTERN
+from .. import DEFAULT_CVE_AUTHORITATIVE_SOURCE, DEFAULT_CVE_URL_PATTERN
 
 
 class CVESync(BaseModel):
@@ -14,6 +14,10 @@ class CVESync(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    cve_authoritative_source: str = Field(
+        default=DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+        description="The authoritative source for CVE data",
+    )
     db_auth_uri: str = Field(
         pattern=r"^mongodb://", description="MongoDB connection URI"
     )

--- a/tests/test_config_model.py
+++ b/tests/test_config_model.py
@@ -5,7 +5,11 @@ from pydantic import ValidationError
 import pytest
 
 # cisagov Libraries
-from cyhy_cvesync.models.config_model import DEFAULT_CVE_URL_PATTERN, CVESync
+from cyhy_cvesync.models.config_model import (
+    DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+    DEFAULT_CVE_URL_PATTERN,
+    CVESync,
+)
 
 
 def test_set_json_url_pattern():
@@ -34,6 +38,15 @@ def test_default_url_concurrency():
         db_name="test_db",
     )
     assert config.url_concurrency == 10
+
+
+def test_default_cve_authoritative_source():
+    """Test the default CVE authoritative source."""
+    config = CVESync(
+        db_auth_uri="mongodb://localhost:27017",
+        db_name="test_db",
+    )
+    assert config.cve_authoritative_source == DEFAULT_CVE_AUTHORITATIVE_SOURCE
 
 
 def test_invalid_db_auth_uri():

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -73,7 +73,11 @@ async def test_process_cve_json_malformed_2():
                     {
                         "cve": {
                             "id": "TEST",
-                            "metrics": {"cvssMetricV30": [{"type": "Primary"}]},
+                            "metrics": {
+                                "cvssMetricV30": [
+                                    {"source": DEFAULT_CVE_AUTHORITATIVE_SOURCE}
+                                ]
+                            },
                         }
                     }
                 ],
@@ -82,7 +86,7 @@ async def test_process_cve_json_malformed_2():
         )
 
 
-async def test_process_cve_json_no_primary_metrics_type(caplog):
+async def test_process_cve_json_no_authoritative_metrics(caplog):
     """Test processing malformed CVE JSON data."""
     cves_created, cves_updated = await process_cve_json(
         {
@@ -92,7 +96,7 @@ async def test_process_cve_json_no_primary_metrics_type(caplog):
                     "cve": {
                         "id": "TEST",
                         "metrics": {
-                            "cvssMetricV30": [{"type": "INVALID", "cvssData": {}}]
+                            "cvssMetricV30": [{"source": "nobody@example.gov"}]
                         },
                     }
                 }
@@ -103,11 +107,112 @@ async def test_process_cve_json_no_primary_metrics_type(caplog):
     assert cves_created == 0, "Expected no CVEs to be created"
     assert cves_updated == 0, "Expected no CVEs to be updated"
     cve_sync_output = caplog.text
-    assert "Skipping TEST; no Primary CVSS v2 or v3 metric found." in cve_sync_output
+    assert (
+        f"Skipping TEST; no CVSS v2 or v3 metric found from authoritative source ({DEFAULT_CVE_AUTHORITATIVE_SOURCE})."
+        in cve_sync_output
+    )
 
 
-async def test_process_cve_json_primary_in_v2(db_uri, db_name):
-    """Test processing CVE JSON data where the primary CVSS metric is v2."""
+async def test_process_cve_json_auth_source_in_v31(db_uri, db_name):
+    """Test processing CVE JSON data where the authoritative CVSS metric is v3.1."""
+    cve_json_v31 = {
+        "format": "NVD_CVE",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "TEST-V31",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+                                "cvssData": {"baseScore": 3.1, "version": "3.1"},
+                            }
+                        ],
+                        "cvssMetricV30": [
+                            {
+                                "source": "nobody@example.gov",
+                                "cvssData": {"baseScore": 3.0, "version": "3.0"},
+                            }
+                        ],
+                        "cvssMetricV2": [
+                            {
+                                "source": "nobody@example.gov",
+                                "cvssData": {"baseScore": 2.0, "version": "2.0"},
+                            }
+                        ],
+                    },
+                }
+            }
+        ],
+    }
+    cves_created, cves_updated = await process_cve_json(
+        cve_json_v31, DEFAULT_CVE_AUTHORITATIVE_SOURCE
+    )
+    assert cves_created == 1, "Expected 1 CVE to be created"
+    assert cves_updated == 0, "Expected no CVEs to be updated"
+
+    client = AsyncMongoClient(db_uri)
+    db = client[db_name]
+    cve_doc = await db.cves.find_one({"_id": "TEST-V31"})
+    assert cve_doc is not None, "Expected CVE document to be found in the database"
+    assert cve_doc["cvss_score"] == 3.1, "Expected CVSS score to be 3.1"
+    assert cve_doc["cvss_version"] == "3.1", "Expected CVSS version to be 3.1"
+
+    # Delete the test CVE document
+    await db.cves.delete_one({"_id": "TEST-V31"})
+
+
+async def test_process_cve_json_auth_source_in_v30(db_uri, db_name):
+    """Test processing CVE JSON data where the authoritative CVSS metric is v3.0."""
+    cve_json_v30 = {
+        "format": "NVD_CVE",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "TEST-V30",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "source": "nobody@example.gov",
+                                "cvssData": {"baseScore": 3.1, "version": "3.1"},
+                            }
+                        ],
+                        "cvssMetricV30": [
+                            {
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+                                "cvssData": {"baseScore": 3.0, "version": "3.0"},
+                            }
+                        ],
+                        "cvssMetricV2": [
+                            {
+                                "source": "nobody@example.gov",
+                                "cvssData": {"baseScore": 2.0, "version": "2.0"},
+                            }
+                        ],
+                    },
+                }
+            }
+        ],
+    }
+    cves_created, cves_updated = await process_cve_json(
+        cve_json_v30, DEFAULT_CVE_AUTHORITATIVE_SOURCE
+    )
+    assert cves_created == 1, "Expected 1 CVE to be created"
+    assert cves_updated == 0, "Expected no CVEs to be updated"
+
+    client = AsyncMongoClient(db_uri)
+    db = client[db_name]
+    cve_doc = await db.cves.find_one({"_id": "TEST-V30"})
+    assert cve_doc is not None, "Expected CVE document to be found in the database"
+    assert cve_doc["cvss_score"] == 3.0, "Expected CVSS score to be 3.0"
+    assert cve_doc["cvss_version"] == "3.0", "Expected CVSS version to be 3.0"
+
+    # Delete the test CVE document
+    await db.cves.delete_one({"_id": "TEST-V30"})
+
+
+async def test_process_cve_json_auth_source_in_v2(db_uri, db_name):
+    """Test processing CVE JSON data where the authoritative CVSS metric is v2."""
     cve_json_v2 = {
         "format": "NVD_CVE",
         "vulnerabilities": [
@@ -117,19 +222,19 @@ async def test_process_cve_json_primary_in_v2(db_uri, db_name):
                     "metrics": {
                         "cvssMetricV31": [
                             {
-                                "type": "Secondary",
+                                "source": "nobody@example.gov",
                                 "cvssData": {"baseScore": 3.1, "version": "3.1"},
                             }
                         ],
                         "cvssMetricV30": [
                             {
-                                "type": "Secondary",
+                                "source": "nobody@example.gov",
                                 "cvssData": {"baseScore": 3.0, "version": "3.0"},
                             }
                         ],
                         "cvssMetricV2": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 2.0, "version": "2.0"},
                             }
                         ],
@@ -247,7 +352,7 @@ async def test_process_urls_create_cves():
                     "metrics": {
                         "cvssMetricV2": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 9.8, "version": "2.0"},
                             }
                         ]
@@ -260,7 +365,7 @@ async def test_process_urls_create_cves():
                     "metrics": {
                         "cvssMetricV30": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 8.5, "version": "3.0"},
                             }
                         ]
@@ -273,7 +378,7 @@ async def test_process_urls_create_cves():
                     "metrics": {
                         "cvssMetricV31": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 4.0, "version": "3.1"},
                             }
                         ]
@@ -305,7 +410,7 @@ async def test_process_urls_update_cves():
                     "metrics": {
                         "cvssMetricV2": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 9.1, "version": "2.0"},
                             }
                         ]
@@ -318,7 +423,7 @@ async def test_process_urls_update_cves():
                     "metrics": {
                         "cvssMetricV30": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 8.5, "version": "3.0"},
                             }
                         ]
@@ -331,7 +436,7 @@ async def test_process_urls_update_cves():
                     "metrics": {
                         "cvssMetricV31": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 7.2, "version": "3.1"},
                             }
                         ]
@@ -363,7 +468,7 @@ async def test_process_urls_delete_cves():
                     "metrics": {
                         "cvssMetricV2": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 9.1, "version": "2.0"},
                             }
                         ]
@@ -376,7 +481,7 @@ async def test_process_urls_delete_cves():
                     "metrics": {
                         "cvssMetricV31": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 7.2, "version": "3.1"},
                             }
                         ]
@@ -408,7 +513,7 @@ async def test_process_urls_create_update_delete_cves():
                     "metrics": {
                         "cvssMetricV2": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 9.3, "version": "2.0"},
                             }
                         ]
@@ -421,7 +526,7 @@ async def test_process_urls_create_update_delete_cves():
                     "metrics": {
                         "cvssMetricV31": [
                             {
-                                "type": "Primary",
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
                                 "cvssData": {"baseScore": 5.5, "version": "3.1"},
                             }
                         ]

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -110,7 +110,7 @@ async def test_process_cve_json_no_authoritative_metrics(caplog):
     assert cves_updated == 0, "Expected no CVEs to be updated"
     cve_sync_output = caplog.text
     assert (
-        f"Skipping TEST; no CVSS v2 or v3 metric found from authoritative source ({DEFAULT_CVE_AUTHORITATIVE_SOURCE})."
+        f"Skipping TEST; no preferred CVSS metrics found from authoritative source ({DEFAULT_CVE_AUTHORITATIVE_SOURCE})."
         in cve_sync_output
     )
 

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -73,24 +73,27 @@ async def test_process_cve_json_malformed_2():
         )
 
 
-async def test_process_cve_json_no_primary_metrics_type():
+async def test_process_cve_json_no_primary_metrics_type(caplog):
     """Test processing malformed CVE JSON data."""
-    with pytest.raises(ValueError, match="No Primary CVSS metric found."):
-        await process_cve_json(
-            {
-                "format": "NVD_CVE",
-                "vulnerabilities": [
-                    {
-                        "cve": {
-                            "id": "TEST",
-                            "metrics": {
-                                "cvssMetricV30": [{"type": "INVALID", "cvssData": {}}]
-                            },
-                        }
+    cves_created, cves_updated = await process_cve_json(
+        {
+            "format": "NVD_CVE",
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": "TEST",
+                        "metrics": {
+                            "cvssMetricV30": [{"type": "INVALID", "cvssData": {}}]
+                        },
                     }
-                ],
-            }
-        )
+                }
+            ],
+        }
+    )
+    assert cves_created == 0, "Expected no CVEs to be created"
+    assert cves_updated == 0, "Expected no CVEs to be updated"
+    cve_sync_output = caplog.text
+    assert "Skipping TEST; no Primary CVSS metric found." in cve_sync_output
 
 
 async def test_process_cve_json_empty_id():

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -87,7 +87,7 @@ async def test_process_cve_json_malformed_2():
 
 
 async def test_process_cve_json_no_authoritative_metrics(caplog):
-    """Test processing malformed CVE JSON data."""
+    """Test processing CVE JSON data containing no authoritative CVSS metrics."""
     # Set DEBUG log level to ensure desired log message is captured
     caplog.set_level("DEBUG")
     cves_created, cves_updated = await process_cve_json(

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -65,7 +65,7 @@ async def test_process_cve_json_malformed_2():
                     {
                         "cve": {
                             "id": "TEST",
-                            "metrics": {"cvssMetricV30": [{"cvssData": {}}]},
+                            "metrics": {"cvssMetricV30": [{"type": "Primary"}]},
                         }
                     }
                 ],
@@ -102,10 +102,14 @@ async def test_process_cve_json_empty_id():
         "format": "NVD_CVE",
         "vulnerabilities": [
             {
-                "cve": {"id": ""},
-                "metrics": {
-                    "baseMetricV31": {"cvssData": {"baseScore": 9.8, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {"cvssData": {"baseScore": 9.8, "version": "3.1"}}
+                        ]
+                    },
+                }
             }
         ],
     }

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -88,6 +88,8 @@ async def test_process_cve_json_malformed_2():
 
 async def test_process_cve_json_no_authoritative_metrics(caplog):
     """Test processing malformed CVE JSON data."""
+    # Set DEBUG log level to ensure desired log message is captured
+    caplog.set_level("DEBUG")
     cves_created, cves_updated = await process_cve_json(
         {
             "format": "NVD_CVE",

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -262,6 +262,55 @@ async def test_process_cve_json_auth_source_in_v2(db_uri, db_name):
     await db.cves.delete_one({"_id": "TEST-V2"})
 
 
+async def test_process_cve_json_multiple_auth_metrics(db_uri, db_name):
+    """Test processing CVE JSON data with multiple authoritative CVSS metrics."""
+    cve_json = {
+        "format": "NVD_CVE",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "TEST-MULTI-AUTH",
+                    "metrics": {
+                        "cvssMetricV2": [
+                            {
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+                                "cvssData": {"baseScore": 2.0, "version": "2.0"},
+                            }
+                        ],
+                        "cvssMetricV30": [
+                            {
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+                                "cvssData": {"baseScore": 3.0, "version": "3.0"},
+                            }
+                        ],
+                        "cvssMetricV31": [
+                            {
+                                "source": DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+                                "cvssData": {"baseScore": 3.1, "version": "3.1"},
+                            }
+                        ],
+                    },
+                }
+            }
+        ],
+    }
+    cves_created, cves_updated = await process_cve_json(
+        cve_json, DEFAULT_CVE_AUTHORITATIVE_SOURCE
+    )
+    assert cves_created == 1, "Expected 1 CVE to be created"
+    assert cves_updated == 0, "Expected no CVEs to be updated"
+
+    client = AsyncMongoClient(db_uri)
+    db = client[db_name]
+    cve_doc = await db.cves.find_one({"_id": "TEST-MULTI-AUTH"})
+    assert cve_doc is not None, "Expected CVE document to be found in the database"
+    assert cve_doc["cvss_score"] == 3.1, "Expected CVSS score to be 3.1"
+    assert cve_doc["cvss_version"] == "3.1", "Expected CVSS version to be 3.1"
+
+    # Delete the test CVE document
+    await db.cves.delete_one({"_id": "TEST-MULTI-AUTH"})
+
+
 async def test_process_cve_json_empty_id():
     """Test processing CVE JSON data with an empty CVE ID."""
     cve_json_empty_id = {

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -93,7 +93,54 @@ async def test_process_cve_json_no_primary_metrics_type(caplog):
     assert cves_created == 0, "Expected no CVEs to be created"
     assert cves_updated == 0, "Expected no CVEs to be updated"
     cve_sync_output = caplog.text
-    assert "Skipping TEST; no Primary CVSS metric found." in cve_sync_output
+    assert "Skipping TEST; no Primary CVSS v2 or v3 metric found." in cve_sync_output
+
+
+async def test_process_cve_json_primary_in_v2(db_uri, db_name):
+    """Test processing CVE JSON data where the primary CVSS metric is v2."""
+    cve_json_v2 = {
+        "format": "NVD_CVE",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "TEST-V2",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "type": "Secondary",
+                                "cvssData": {"baseScore": 3.1, "version": "3.1"},
+                            }
+                        ],
+                        "cvssMetricV30": [
+                            {
+                                "type": "Secondary",
+                                "cvssData": {"baseScore": 3.0, "version": "3.0"},
+                            }
+                        ],
+                        "cvssMetricV2": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 2.0, "version": "2.0"},
+                            }
+                        ],
+                    },
+                }
+            }
+        ],
+    }
+    cves_created, cves_updated = await process_cve_json(cve_json_v2)
+    assert cves_created == 1, "Expected 1 CVE to be created"
+    assert cves_updated == 0, "Expected no CVEs to be updated"
+
+    client = AsyncMongoClient(db_uri)
+    db = client[db_name]
+    cve_doc = await db.cves.find_one({"_id": "TEST-V2"})
+    assert cve_doc is not None, "Expected CVE document to be found in the database"
+    assert cve_doc["cvss_score"] == 2.0, "Expected CVSS score to be 2.0"
+    assert cve_doc["cvss_version"] == "2.0", "Expected CVSS version to be 2.0"
+
+    # Delete the test CVE document
+    await db.cves.delete_one({"_id": "TEST-V2"})
 
 
 async def test_process_cve_json_empty_id():

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -38,10 +38,10 @@ async def test_connection_motor(db_uri, db_name):
     assert server_info["ok"] == 1.0, "Direct database ping failed"
 
 
-async def test_process_cve_json_invalid_cve_data_type():
+async def test_process_cve_json_invalid_format():
     """Test processing invalid CVE JSON data."""
     with pytest.raises(ValueError, match="JSON does not look like valid CVE data."):
-        await process_cve_json({"CVE_data_type": "INVALID", "CVE_Items": []})
+        await process_cve_json({"format": "INVALID", "vulnerabilities": []})
 
 
 async def test_process_cve_json_malformed_1():
@@ -49,8 +49,8 @@ async def test_process_cve_json_malformed_1():
     with pytest.raises(ValueError, match="JSON does not look like valid CVE data."):
         await process_cve_json(
             {
-                "CVE_data_type": "CVE",
-                "CVE_Items": [{"cve": {"CVE_data_meta": {"INVALID": "FOOBAR"}}}],
+                "format": "NVD_CVE",
+                "vulnerabilities": [{"cve": {"metrics": {"INVALID": "FOOBAR"}}}],
             }
         )
 
@@ -60,11 +60,33 @@ async def test_process_cve_json_malformed_2():
     with pytest.raises(ValueError, match="JSON does not look like valid CVE data."):
         await process_cve_json(
             {
-                "CVE_data_type": "CVE",
-                "CVE_Items": [
+                "format": "NVD_CVE",
+                "vulnerabilities": [
                     {
-                        "cve": {"CVE_data_meta": {"ID": "TEST"}},
-                        "impact": {"baseMetricV3": {"cvssV3": {}}},
+                        "cve": {
+                            "id": "TEST",
+                            "metrics": {"cvssMetricV30": [{"cvssData": {}}]},
+                        }
+                    }
+                ],
+            }
+        )
+
+
+async def test_process_cve_json_no_primary_metrics_type():
+    """Test processing malformed CVE JSON data."""
+    with pytest.raises(ValueError, match="No Primary CVSS metric found."):
+        await process_cve_json(
+            {
+                "format": "NVD_CVE",
+                "vulnerabilities": [
+                    {
+                        "cve": {
+                            "id": "TEST",
+                            "metrics": {
+                                "cvssMetricV30": [{"type": "INVALID", "cvssData": {}}]
+                            },
+                        }
                     }
                 ],
             }
@@ -74,12 +96,12 @@ async def test_process_cve_json_malformed_2():
 async def test_process_cve_json_empty_id():
     """Test processing CVE JSON data with an empty CVE ID."""
     cve_json_empty_id = {
-        "CVE_data_type": "CVE",
-        "CVE_Items": [
+        "format": "NVD_CVE",
+        "vulnerabilities": [
             {
-                "cve": {"CVE_data_meta": {"ID": ""}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 9.8, "version": "3.1"}}
+                "cve": {"id": ""},
+                "metrics": {
+                    "baseMetricV31": {"cvssData": {"baseScore": 9.8, "version": "3.1"}}
                 },
             }
         ],
@@ -142,32 +164,55 @@ async def test_fetch_real_cve_data():
     cve_url = DEFAULT_CVE_URL_PATTERN.format(year=2024)
     async with ClientSession() as session:
         cve_json = await fetch_cve_data(session, cve_url, gzipped=True)
-    assert "CVE_Items" in cve_json, "Expected 'CVE_Items' in CVE data"
-    assert len(cve_json["CVE_Items"]) > 0, "Expected at least one CVE item in CVE data"
+    assert "vulnerabilities" in cve_json, "Expected 'vulnerabilities' in CVE data"
+    assert (
+        len(cve_json["vulnerabilities"]) > 0
+    ), "Expected at least one CVE item in CVE data"
 
 
 async def test_process_urls_create_cves():
     """Test processing URLs where new CVEs are created."""
     cve_json_data = {
-        "CVE_data_type": "CVE",
-        "CVE_Items": [
+        "format": "NVD_CVE",
+        "vulnerabilities": [
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-1"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 9.8, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-1",
+                    "metrics": {
+                        "cvssMetricV2": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 9.8, "version": "2.0"},
+                            }
+                        ]
+                    },
+                }
             },
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-2"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 8.5, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-2",
+                    "metrics": {
+                        "cvssMetricV30": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 8.5, "version": "3.0"},
+                            }
+                        ]
+                    },
+                }
             },
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-3"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 4.0, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-3",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 4.0, "version": "3.1"},
+                            }
+                        ]
+                    },
+                }
             },
         ],
     }
@@ -183,25 +228,46 @@ async def test_process_urls_create_cves():
 async def test_process_urls_update_cves():
     """Test processing URLs where CVEs are updated."""
     cve_json_data = {
-        "CVE_data_type": "CVE",
-        "CVE_Items": [
+        "format": "NVD_CVE",
+        "vulnerabilities": [
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-1"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 9.1, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-1",
+                    "metrics": {
+                        "cvssMetricV2": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 9.1, "version": "2.0"},
+                            }
+                        ]
+                    },
+                }
             },
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-2"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 8.5, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-2",
+                    "metrics": {
+                        "cvssMetricV30": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 8.5, "version": "3.0"},
+                            }
+                        ]
+                    },
+                }
             },
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-3"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 7.2, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-3",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 7.2, "version": "3.1"},
+                            }
+                        ]
+                    },
+                }
             },
         ],
     }
@@ -217,19 +283,33 @@ async def test_process_urls_update_cves():
 async def test_process_urls_delete_cves():
     """Test processing URLs where CVEs are deleted."""
     cve_json_data = {
-        "CVE_data_type": "CVE",
-        "CVE_Items": [
+        "format": "NVD_CVE",
+        "vulnerabilities": [
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-1"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 9.1, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-1",
+                    "metrics": {
+                        "cvssMetricV2": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 9.1, "version": "2.0"},
+                            }
+                        ]
+                    },
+                }
             },
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-3"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 7.2, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-3",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 7.2, "version": "3.1"},
+                            }
+                        ]
+                    },
+                }
             },
         ],
     }
@@ -245,19 +325,33 @@ async def test_process_urls_delete_cves():
 async def test_process_urls_create_update_delete_cves():
     """Test processing URLs where CVEs are created, updated, and deleted."""
     cve_json_data = {
-        "CVE_data_type": "CVE",
-        "CVE_Items": [
+        "format": "NVD_CVE",
+        "vulnerabilities": [
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-1"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 9.3, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-1",
+                    "metrics": {
+                        "cvssMetricV2": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 9.3, "version": "2.0"},
+                            }
+                        ]
+                    },
+                }
             },
             {
-                "cve": {"CVE_data_meta": {"ID": "CVE-TEST-4"}},
-                "impact": {
-                    "baseMetricV3": {"cvssV3": {"baseScore": 5.5, "version": "3.1"}}
-                },
+                "cve": {
+                    "id": "CVE-TEST-4",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "type": "Primary",
+                                "cvssData": {"baseScore": 5.5, "version": "3.1"},
+                            }
+                        ]
+                    },
+                }
             },
         ],
     }

--- a/tests/test_cvesync.py
+++ b/tests/test_cvesync.py
@@ -12,7 +12,11 @@ from pymongo import AsyncMongoClient
 import pytest
 
 # cisagov Libraries
-from cyhy_cvesync import DEFAULT_CVE_URL_PATTERN, __version__
+from cyhy_cvesync import (
+    DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+    DEFAULT_CVE_URL_PATTERN,
+    __version__,
+)
 from cyhy_cvesync.cve_sync import fetch_cve_data, process_cve_json, process_urls
 
 # define sources of version strings
@@ -41,7 +45,10 @@ async def test_connection_motor(db_uri, db_name):
 async def test_process_cve_json_invalid_format():
     """Test processing invalid CVE JSON data."""
     with pytest.raises(ValueError, match="JSON does not look like valid CVE data."):
-        await process_cve_json({"format": "INVALID", "vulnerabilities": []})
+        await process_cve_json(
+            {"format": "INVALID", "vulnerabilities": []},
+            DEFAULT_CVE_AUTHORITATIVE_SOURCE,
+        )
 
 
 async def test_process_cve_json_malformed_1():
@@ -51,7 +58,8 @@ async def test_process_cve_json_malformed_1():
             {
                 "format": "NVD_CVE",
                 "vulnerabilities": [{"cve": {"metrics": {"INVALID": "FOOBAR"}}}],
-            }
+            },
+            DEFAULT_CVE_AUTHORITATIVE_SOURCE,
         )
 
 
@@ -69,7 +77,8 @@ async def test_process_cve_json_malformed_2():
                         }
                     }
                 ],
-            }
+            },
+            DEFAULT_CVE_AUTHORITATIVE_SOURCE,
         )
 
 
@@ -88,7 +97,8 @@ async def test_process_cve_json_no_primary_metrics_type(caplog):
                     }
                 }
             ],
-        }
+        },
+        DEFAULT_CVE_AUTHORITATIVE_SOURCE,
     )
     assert cves_created == 0, "Expected no CVEs to be created"
     assert cves_updated == 0, "Expected no CVEs to be updated"
@@ -128,7 +138,9 @@ async def test_process_cve_json_primary_in_v2(db_uri, db_name):
             }
         ],
     }
-    cves_created, cves_updated = await process_cve_json(cve_json_v2)
+    cves_created, cves_updated = await process_cve_json(
+        cve_json_v2, DEFAULT_CVE_AUTHORITATIVE_SOURCE
+    )
     assert cves_created == 1, "Expected 1 CVE to be created"
     assert cves_updated == 0, "Expected no CVEs to be updated"
 
@@ -161,7 +173,7 @@ async def test_process_cve_json_empty_id():
         ],
     }
     with pytest.raises(ValueError, match="CVE ID is empty."):
-        await process_cve_json(cve_json_empty_id)
+        await process_cve_json(cve_json_empty_id, DEFAULT_CVE_AUTHORITATIVE_SOURCE)
 
 
 async def test_fetch_cve_data_invalid_url_scheme():
@@ -272,7 +284,10 @@ async def test_process_urls_create_cves():
     }
     with patch("cyhy_cvesync.cve_sync.fetch_cve_data", return_value=cve_json_data):
         created, updated, deleted = await process_urls(
-            ["https://example.com/cve.json"], cve_data_gzipped=False, concurrency=1
+            ["https://example.com/cve.json"],
+            cve_data_gzipped=False,
+            concurrency=1,
+            cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE,
         )
         assert created == 3, "Expected 3 CVEs to be created"
         assert updated == 0, "Expected no CVEs to be updated"
@@ -327,7 +342,10 @@ async def test_process_urls_update_cves():
     }
     with patch("cyhy_cvesync.cve_sync.fetch_cve_data", return_value=cve_json_data):
         created, updated, deleted = await process_urls(
-            ["https://example.com/cve.json"], cve_data_gzipped=False, concurrency=1
+            ["https://example.com/cve.json"],
+            cve_data_gzipped=False,
+            concurrency=1,
+            cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE,
         )
         assert created == 0, "Expected no CVEs to be created"
         assert updated == 2, "Expected 2 CVEs to be updated"
@@ -369,7 +387,10 @@ async def test_process_urls_delete_cves():
     }
     with patch("cyhy_cvesync.cve_sync.fetch_cve_data", return_value=cve_json_data):
         created, updated, deleted = await process_urls(
-            ["https://example.com/cve.json"], cve_data_gzipped=False, concurrency=1
+            ["https://example.com/cve.json"],
+            cve_data_gzipped=False,
+            concurrency=1,
+            cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE,
         )
         assert created == 0, "Expected no CVEs to be created"
         assert updated == 0, "Expected no CVEs to be updated"
@@ -411,7 +432,10 @@ async def test_process_urls_create_update_delete_cves():
     }
     with patch("cyhy_cvesync.cve_sync.fetch_cve_data", return_value=cve_json_data):
         created, updated, deleted = await process_urls(
-            ["https://example.com/cve.json"], cve_data_gzipped=False, concurrency=1
+            ["https://example.com/cve.json"],
+            cve_data_gzipped=False,
+            concurrency=1,
+            cve_authoritative_source=DEFAULT_CVE_AUTHORITATIVE_SOURCE,
         )
         assert created == 1, "Expected 1 CVE to be created"
         assert updated == 1, "Expected 1 CVE to be updated"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,14 +39,8 @@ count = 0
 hits = 0
 for cve in SAMPLE_CVE_JSON["vulnerabilities"]:
     count += 1
-    if any(
-        k in cve["cve"].get("metrics", {})
-        for k in [
-            "cvssMetricV2",
-            "cvssMetricV30",
-            "cvssMetricV31",
-        ]
-    ):
+    metrics = cve.get("cve", {}).get("metrics", {}).keys()
+    if metrics & {"cvssMetricV31", "cvssMetricV30", "cvssMetricV2"}:
         hits += 1
     if hits == SAMPLE_CVE_JSON_SMALL_VALID_CVES:
         break

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,14 +37,21 @@ SAMPLE_CVE_JSON = asyncio.run(fetch_sample_cve_data(2024))
 SAMPLE_CVE_JSON_SMALL_VALID_CVES = 20
 count = 0
 hits = 0
-for cve in SAMPLE_CVE_JSON["CVE_Items"]:
+for cve in SAMPLE_CVE_JSON["vulnerabilities"]:
     count += 1
-    if any(k in cve["impact"] for k in ["baseMetricV2", "baseMetricV3"]):
+    if any(
+        k in cve["cve"].get("metrics", {})
+        for k in [
+            "cvssMetricV2",
+            "cvssMetricV30",
+            "cvssMetricV31",
+        ]
+    ):
         hits += 1
     if hits == SAMPLE_CVE_JSON_SMALL_VALID_CVES:
         break
 SAMPLE_CVE_JSON_SMALL = SAMPLE_CVE_JSON.copy()
-SAMPLE_CVE_JSON_SMALL["CVE_Items"] = SAMPLE_CVE_JSON["CVE_Items"][:count]
+SAMPLE_CVE_JSON_SMALL["vulnerabilities"] = SAMPLE_CVE_JSON["vulnerabilities"][:count]
 
 
 async def test_main_async_no_args():


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the code in this repository to use [v2.0 of the NIST NVD JSON](https://nvd.nist.gov/vuln/data-feeds#divJson20Feeds), instead of the now-deprecated v1.1.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The v1.1 files were decommissioned on Aug. 20, 2025 per the info below from https://www.nist.gov/itl/nvd:

> Decommissioning of Legacy Data Feed Files
>
> As of August 20th, 2025, the following legacy Data Feed files have been removed from the NVD [Data Feeds Page](https://nvd.nist.gov/vuln/data-feeds) and are no longer available for access or download 
>
> - 1.1 Vulnerability Feeds
> - 1.0 CPE Match Feed
> - XML CPE Dictionary Files to include the Official CPE 2.2 and 2.3 Dictionary .zip and .gz
>
> Any organizations making use of the legacy feed files will need to update their systems to use the 2.0 APIs or the 2.0 data feed files. 

Also noted in https://github.com/cisagov/cyhy-core/issues/73#issuecomment-3215272857.

Note similar changes are found in https://github.com/cisagov/cyhy-core/pull/103.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

All automated tests pass.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
